### PR TITLE
add showChildren by default

### DIFF
--- a/jquery.slicknav.js
+++ b/jquery.slicknav.js
@@ -18,7 +18,7 @@
 		parentTag: 'a',
 		closeOnClick: false,
 		allowParentLinks: false,
-        nestedParentLinks: true,
+        	nestedParentLinks: true,
 		showChildren: false,
 		init: function(){},
 		open: function(){},


### PR DESCRIPTION
Add a setting to show the children of any link by default. Defaults to false. Also, cosmetic fix.
