### PR TITLE
Add additional css class to the menu.

### DIFF
--- a/jquery.slicknav.js
+++ b/jquery.slicknav.js
@@ -20,6 +20,7 @@
         allowParentLinks: false,
         nestedParentLinks: true,
         showChildren: false,
+        additionalClass: false,
         init: function(){},
         open: function(){},
         close: function(){}
@@ -73,6 +74,12 @@
         // create menu bar
         $this.mobileNav.attr('class', prefix+'_nav');
         var menuBar = $('<div class="'+prefix+'_menu"></div>');
+
+        // add the additional class to the menu if available.
+        if (settings.additionalClass) {
+          menuBar.addClass(settings.additionalClass);
+        }
+
         $this.btn = $('<'+settings.parentTag+' aria-haspopup="true" tabindex="0" class="'+prefix+'_btn '+prefix+'_collapsed"><span class="'+prefix+'_menutxt">'+settings.label+'</span><span class="'+iconClass+'"><span class="'+prefix+'_icon-bar"></span><span class="'+prefix+'_icon-bar"></span><span class="'+prefix+'_icon-bar"></span></span></a>');
         $(menuBar).append($this.btn);        
         $(settings.prependTo).prepend(menuBar);


### PR DESCRIPTION
I had a use case where I had two menus on the same page and I needed to change the css on them to look different. I added the 'additionalClass' setting to allow a user to specify a class to add to the menu during init.