### PR TITLE
Change the button creation code to use an array*

### DIFF
--- a/jquery.slicknav.js
+++ b/jquery.slicknav.js
@@ -73,8 +73,18 @@
         // create menu bar
         $this.mobileNav.attr('class', prefix+'_nav');
         var menuBar = $('<div class="'+prefix+'_menu"></div>');
-        $this.btn = $('<'+settings.parentTag+' aria-haspopup="true" tabindex="0" class="'+prefix+'_btn '+prefix+'_collapsed"><span class="'+prefix+'_menutxt">'+settings.label+'</span><span class="'+iconClass+'"><span class="'+prefix+'_icon-bar"></span><span class="'+prefix+'_icon-bar"></span><span class="'+prefix+'_icon-bar"></span></span></a>');
-        $(menuBar).append($this.btn);        
+        $this.btn = $(
+            ['<'+settings.parentTag+' aria-haspopup="true" tabindex="0" class="'+prefix+'_btn '+prefix+'_collapsed">',
+                '<span class="'+prefix+'_menutxt">'+settings.label+'</span>',
+                '<span class="'+iconClass+'">',
+                    '<span class="'+prefix+'_icon-bar"></span>',
+                    '<span class="'+prefix+'_icon-bar"></span>',
+                    '<span class="'+prefix+'_icon-bar"></span>',
+                '</span>',
+            '</'+settings.parentTag+'>'
+            ].join('')
+        );
+        $(menuBar).append($this.btn);
         $(settings.prependTo).prepend(menuBar);
         menuBar.append($this.mobileNav);
         


### PR DESCRIPTION
- I feel like this is a slightly less inscrutable way of generating the button/hamburger markup
- Previously `settings.parentTag` was being closed with a hard coded `</a>`
  - I'm assuming this was generally never raised as an issue because most people are probably using anchor links as parent tags anyway
  - Failing to do so would possibly be cleaned up by jQuery's html creation code, but better to be sure

<sub>
*the author of this pull request fully acknowledges that this pull request may at first glance appear to be a coarse  waste of the Very Busy Original Author of the Plugin's time, and if so, apologises, and herein offers this photograph of a golden retriever swimming with a dolphin in the hope that this may offer an enjoyable diversion to the aforementioned and presumably Very Busy plugin author</sub>

![](http://31.media.tumblr.com/dc0e0d929ea0a5be5349130b00508479/tumblr_mqk32k2PaZ1sbmaxlo1_1280.jpg)
