### PR TITLE
Ensure Keyboard variable declared

### DIFF
--- a/jquery.slicknav.js
+++ b/jquery.slicknav.js
@@ -28,7 +28,7 @@
             afterClose: function () {}
         },
         mobileMenu = 'slicknav',
-        prefix = 'slicknav';
+        prefix = 'slicknav',
 
         Keyboard = {
             DOWN: 40,


### PR DESCRIPTION
'Keyboard' variable is not declared with the var keyword.

On MacOS Sierra this results in a JS error:

`[Error] ReferenceError: Can't find variable: Keyboard`