### PR TITLE
Added code and a setting to allow unfold of child menus on hover

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ slicknav.css can be modified to fit website design
     'allowParentLinks': false // Allow clickable links as parent elements.
     'nestedParentLinks': true // If false, parent links will be separated from the sub-menu toggle.
     'showChildren': false // Show children of parent links by default.
+    'showChildrenOnHover': false // Show children of parent links when hovering over parent.
     'removeIds': true // Remove IDs from all menu elements. Defaults to false if duplicate set to false.
     'removeClasses': false // Remove classes from all menu elements.
 	'brand': '' // Add branding to menu bar.

--- a/jquery.slicknav.js
+++ b/jquery.slicknav.js
@@ -16,6 +16,7 @@
             allowParentLinks: false,
             nestedParentLinks: true,
             showChildren: false,
+            showChildrenOnHover: false,
             removeIds: true,
             removeClasses: false,
             removeStyles: false,
@@ -256,6 +257,37 @@
             e.preventDefault();
             $this._itemClick($(this));
         });
+
+        // toggle submenus on hover
+        if (settings.showChildrenOnHover) {
+            $('.'+prefix+'_parent,.'+prefix+'_open' ).mouseenter(function (event) {
+                event.preventDefault();
+                var parentEl=$(event.target).closest('.'+prefix+'_parent');
+                var sub_menu = parentEl.children('ul');
+                if (!parentEl.hasClass(prefix+'_collapsed')) {
+                    return;
+                }
+                parentEl.removeClass(prefix+'_collapsed');
+                parentEl.addClass(prefix+'_open');
+                parentEl.addClass(prefix+'_animating');
+                var arrow = parentEl.children('.'+prefix+'_item').children('.'+prefix+'_arrow');
+                arrow.html(settings.openedSymbol);
+                $this._visibilityToggle(sub_menu, parentEl, true, parentEl);
+            }).mouseleave(function (event) {
+                event.preventDefault();
+                var parentEl=$(event.target).closest('.'+prefix+'_parent');
+                var sub_menu = parentEl.children('ul');
+                if (!parentEl.hasClass(prefix+'_open')) {
+                    return;
+                }
+                parentEl.addClass(prefix+'_collapsed');
+                parentEl.removeClass(prefix+'_open');
+                parentEl.addClass(prefix+'_animating');
+                var arrow = parentEl.children('.'+prefix+'_item').children('.'+prefix+'_arrow');
+                arrow.html(settings.closedSymbol);
+                $this._visibilityToggle(sub_menu, parentEl, true, parentEl);
+            });
+        }
 
         // check for keyboard events on menu button and menu parents
         $($this.btn).keydown(function (e) {


### PR DESCRIPTION
Hi there!
First of all, thank you for this nice little menu, it's been really handy.
There was a feature I was asked for that was to unfold sub-menus on hover over the parent. The request was justified by the fact that you wouldn't have to understand that the little arrow means "click to unfold" (which I agree, is fairly clear, but that's apparently not the case for everybody), and also avoids confusion when you click on a parent element's link and go to that page, when the sub-menu possibly goes unnoticed.
So here is my proposed way to do that. I'm absolutely no expert in jQuery, so if anything is not clean or standard, I'm very pleased to hear criticism.
Best regards,
Mark.