### PR TITLE
Add aria-label attribute to menu button (accessibility)

### DIFF
--- a/jquery.slicknav.js
+++ b/jquery.slicknav.js
@@ -118,7 +118,7 @@
 			$(menuBar).append(brand);
 		}
         $this.btn = $(
-            ['<' + settings.parentTag + ' aria-haspopup="true" role="button" tabindex="0" class="' + prefix + '_btn ' + prefix + '_collapsed">',
+            ['<' + settings.parentTag + ' aria-label="' + settings.label + '" aria-haspopup="true" role="button" tabindex="0" class="' + prefix + '_btn ' + prefix + '_collapsed">',
                 '<span class="' + prefix + '_menutxt">' + settings.label + '</span>',
                 '<span class="' + iconClass + '">',
                     '<span class="' + prefix + '_icon-bar"></span>',


### PR DESCRIPTION
Added aria-label attribute to the actual button markup, as adding the menu label to the nested `span` only works if you want to display the label text. If you don't (`display: none;`) you lose out on accessibility. aria-label fixes this.