### PR TITLE
Fix deprecated jQuery calls with jQuery 3.5.

### DIFF
--- a/jquery.slicknav.js
+++ b/jquery.slicknav.js
@@ -200,7 +200,7 @@
             }
 
             // accessibility for links
-            item.children('a').attr('role', 'menuitem').click(function(event){
+            item.children('a').attr('role', 'menuitem').on('click', function(event){
                 //Ensure that it's not a parent
                 if (settings.closeOnClick && !$(event.target).parent().closest('li').hasClass(prefix+'_parent')) {
                         //Emulate menu close if set
@@ -210,12 +210,12 @@
 
             //also close on click if parent links are set
             if (settings.closeOnClick && settings.allowParentLinks) {
-                item.children('a').children('a').click(function (event) {
+                item.children('a').children('a').on('click', function(event) {
                     //Emulate menu close
                     $($this.btn).click();
                 });
 
-                item.find('.'+prefix+'_parent-link a:not(.'+prefix+'_item)').click(function(event){
+                item.find('.'+prefix+'_parent-link a:not(.'+prefix+'_item)').on('click', function(event){
                     //Emulate menu close
                         $($this.btn).click();
                 });
@@ -237,16 +237,16 @@
         $this.mobileNav.attr('role','menu');
 
         // outline prevention when using mouse
-        $(document).mousedown(function(){
+        $(document).on('mousedown', function(){
             $this._outlines(false);
         });
 
-        $(document).keyup(function(){
+        $(document).on('keyup', function(){
             $this._outlines(true);
         });
 
         // menu button click
-        $($this.btn).click(function (e) {
+        $($this.btn).on('click', function (e) {
             e.preventDefault();
             $this._menuToggle();
         });
@@ -258,7 +258,7 @@
         });
 
         // check for keyboard events on menu button and menu parents
-        $($this.btn).keydown(function (e) {
+        $($this.btn).on('keydown', function (e) {
             var ev = e || event;
 
             switch(ev.keyCode) {
@@ -269,12 +269,12 @@
                     if (ev.keyCode !== Keyboard.DOWN || !$($this.btn).hasClass(prefix+'_open')){
                         $this._menuToggle();
                     }
-                    
+
                     $($this.btn).next().find('[role="menuitem"]').first().focus();
                     break;
             }
 
-            
+
         });
 
         $this.mobileNav.on('keydown', '.'+prefix+'_item', function(e) {
@@ -332,13 +332,13 @@
                     e.preventDefault();
                     $this._menuToggle();
                     $($this.btn).focus();
-                    break;    
+                    break;
             }
         });
 
         // allow links clickable within parent tags if set
         if (settings.allowParentLinks && settings.nestedParentLinks) {
-            $('.'+prefix+'_item a').click(function(e){
+            $('.'+prefix+'_item a').on('click', function(e){
                     e.stopImmediatePropagation();
             });
         }
@@ -402,7 +402,7 @@
         if (animate) {
             duration = settings.duration;
         }
-        
+
         function afterOpen(trigger, parent) {
             $(trigger).removeClass(prefix+'_animating');
             $(parent).removeClass(prefix+'_animating');
@@ -412,7 +412,7 @@
                 settings.afterOpen(trigger);
             }
         }
-        
+
         function afterClose(trigger, parent) {
             el.attr('aria-hidden','true');
             items.attr('tabindex', '-1');
@@ -465,7 +465,7 @@
                     afterClose(trigger, parent)
                 });
             } else if (settings.animations === 'velocity') {
-                
+
                 el.velocity("finish").velocity("slideUp", {
                     duration: duration,
                     easing: settings.easingClose,


### PR DESCRIPTION
Fix deprecated jQuery calls with jQuery 3.5.

This can be tested by using jQuery 3.5 together with jQuery-Migrate.